### PR TITLE
Set nginx server to be SSL on port 8443

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,108 @@
+# For more information on configuration, see:
+#   * Official English Documentation: http://nginx.org/en/docs/
+#   * Official Russian Documentation: http://nginx.org/ru/docs/
+#
+#
+#   Streams-endpoint
+
+
+worker_processes auto;
+error_log /var/opt/rh/rh-nginx112/log/nginx/error.log;
+pid /var/opt/rh/rh-nginx112/run/nginx/nginx.pid;
+
+# Load dynamic modules. See /opt/rh/rh-nginx112/root/usr/share/doc/README.dynamic.
+include /opt/rh/rh-nginx112/root/usr/share/nginx/modules/*.conf;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/opt/rh/rh-nginx112/log/nginx/access.log  main;
+
+    sendfile        on;
+    tcp_nopush      on;
+    tcp_nodelay     on;
+    keepalive_timeout  65;
+    types_hash_max_size 2048;
+
+    include       /etc/opt/rh/rh-nginx112/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    # Load modular configuration files from the /etc/nginx/conf.d directory.
+    # See http://nginx.org/en/docs/ngx_core_module.html#include
+    # for more information.
+    include /opt/app-root/etc/nginx.d/*.conf;
+
+    server {
+        listen       8080 default_server;
+        listen       [::]:8080 default_server;
+        server_name  _;
+        root         /opt/app-root/src;
+
+        # Load configuration files for the default server block.
+        include      /opt/app-root/etc/nginx.default.d/*.conf;
+
+        location / {
+        }
+
+        error_page 404 /404.html;
+        location = /40x.html {
+        }
+
+        error_page 500 502 503 504  /50x.html;
+        location = /50x.html {
+        }
+
+        # proxy the PHP scripts to Apache listening on 127.0.0.1:8080
+        #
+        #location ~ \.php$ {
+        #    proxy_pass   http://127.0.0.1;
+        #}
+
+        # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+        #
+        #location ~ \.php$ {
+        #    root           html;
+        #    fastcgi_pass   127.0.0.1:9000;
+        #    fastcgi_index  index.php;
+        #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+        #    include        fastcgi_params;
+        #}
+
+        # deny access to .htaccess files, if Apache's document root
+        # concurs with nginx's one
+        #
+        #location ~ /\.ht {
+        #    deny  all;
+        #}
+    }
+
+
+    # HTTPS server
+    #
+    #server {
+    #    listen       443;
+    #    server_name  localhost;
+
+    #    ssl                  on;
+    #    ssl_certificate      cert.pem;
+    #    ssl_certificate_key  cert.key;
+
+    #    ssl_session_timeout  5m;
+
+    #    ssl_protocols  SSLv2 SSLv3 TLSv1;
+    #    ssl_ciphers  HIGH:!aNULL:!MD5;
+    #    ssl_prefer_server_ciphers   on;
+
+    #    location / {
+    #        root   html;
+    #        index  index.html index.htm;
+    #    }
+    #}
+
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -39,10 +39,20 @@ http {
     include /opt/app-root/etc/nginx.d/*.conf;
 
     server {
-        listen       8080 default_server;
-        listen       [::]:8080 default_server;
+        listen       8443 default_server;
+        listen       [::]:8443 default_server;
         server_name  _;
         root         /opt/app-root/src;
+
+        ssl                  on;
+        ssl_certificate      /var/run/secrets/endpoint-monitor/tls.crt;
+        ssl_certificate_key  /var/run/secrets/endpoint-monitor/tls.key;
+
+        ssl_session_timeout  5m;
+
+        ssl_protocols  SSLv2 SSLv3 TLSv1;
+        ssl_ciphers  HIGH:!aNULL:!MD5;
+        ssl_prefer_server_ciphers   on;
 
         # Load configuration files for the default server block.
         include      /opt/app-root/etc/nginx.default.d/*.conf;
@@ -81,28 +91,4 @@ http {
         #    deny  all;
         #}
     }
-
-
-    # HTTPS server
-    #
-    #server {
-    #    listen       443;
-    #    server_name  localhost;
-
-    #    ssl                  on;
-    #    ssl_certificate      cert.pem;
-    #    ssl_certificate_key  cert.key;
-
-    #    ssl_session_timeout  5m;
-
-    #    ssl_protocols  SSLv2 SSLv3 TLSv1;
-    #    ssl_ciphers  HIGH:!aNULL:!MD5;
-    #    ssl_prefer_server_ciphers   on;
-
-    #    location / {
-    #        root   html;
-    #        index  index.html index.htm;
-    #    }
-    #}
-
 }

--- a/openshift/templates/streams-endpoints.json
+++ b/openshift/templates/streams-endpoints.json
@@ -224,7 +224,7 @@
                 ],
                 "ports": [
                   {
-                    "containerPort": 8080
+                    "containerPort": 8443
                   }
                 ],
                 "readinessProbe": {
@@ -232,7 +232,7 @@
                   "initialDelaySeconds": 3,
                   "httpGet": {
                     "path": "/",
-                    "port": 8080
+                    "port": 8443
                   }
                 },
                 "livenessProbe": {
@@ -240,7 +240,7 @@
                     "initialDelaySeconds": 30,
                     "httpGet": {
                         "path": "/",
-                        "port": 8080
+                        "port": 8443
                     }
                 },
                 "resources": {
@@ -287,8 +287,8 @@
         "ports": [
           {
             "name": "web",
-            "port": 8080,
-            "targetPort": 8080
+            "port": 8443,
+            "targetPort": 8443
           }
         ],
         "selector": {

--- a/openshift/templates/streams-endpoints.json
+++ b/openshift/templates/streams-endpoints.json
@@ -212,7 +212,7 @@
           "spec": {
             "volumes": [
                 {"name": "nginx-job-configs", "emptyDir": {}},
-                {"name": "nginx-server-cert", "secret": {"name": "${NAME}-cert"}},
+                {"name": "nginx-server-cert", "secret": {"name": "${NAME}-cert"}}
             ],
             "containers": [
               {

--- a/openshift/templates/streams-endpoints.json
+++ b/openshift/templates/streams-endpoints.json
@@ -216,7 +216,7 @@
                 "name": "streams-nginx",
                 "image": "${NAME}-nginx:latest",
                 "volumeMounts": [
-                     {"name": "nginx-job-configs", "mountPath": "/opt/streams_job_configs"}
+                     {"name": "nginx-job-configs", "mountPath": "/opt/streams_job_configs"},
                      {"name": "${NAME}-nginx-cert", "mountPath": "/var/run/secrets/endpoint-monitor", "readOnly":true}
                 ],
                 "ports": [
@@ -276,7 +276,7 @@
       "metadata": {
         "name": "${NAME}",
         "annotations": {
-          "service.alpha.openshift.io/serving-cert-secret-name": "${NAME}-nginx-cert"
+          "service.alpha.openshift.io/serving-cert-secret-name": "${NAME}-nginx-cert",
           "description": "Exposes IBM Streams application endpoints"
         }
       },

--- a/openshift/templates/streams-endpoints.json
+++ b/openshift/templates/streams-endpoints.json
@@ -212,7 +212,7 @@
           "spec": {
             "volumes": [
                 {"name": "nginx-job-configs", "emptyDir": {}},
-                {"name": "nginx-server-cert", "secret": {"name": "${NAME}-cert"}}
+                {"name": "nginx-server-cert", "secret": {"secretName": "${NAME}-cert"}}
             ],
             "containers": [
               {

--- a/openshift/templates/streams-endpoints.json
+++ b/openshift/templates/streams-endpoints.json
@@ -215,7 +215,10 @@
               {
                 "name": "streams-nginx",
                 "image": "${NAME}-nginx:latest",
-                "volumeMounts": [ {"name": "nginx-job-configs", "mountPath": "/opt/streams_job_configs"}],
+                "volumeMounts": [
+                     {"name": "nginx-job-configs", "mountPath": "/opt/streams_job_configs"}
+                     {"name": "${NAME}-nginx-cert", "mountPath": "/var/run/secrets/endpoint-monitor", "readOnly":true}
+                ],
                 "ports": [
                   {
                     "containerPort": 8080
@@ -273,6 +276,7 @@
       "metadata": {
         "name": "${NAME}",
         "annotations": {
+          "service.alpha.openshift.io/serving-cert-secret-name": "${NAME}-nginx-cert"
           "description": "Exposes IBM Streams application endpoints"
         }
       },

--- a/openshift/templates/streams-endpoints.json
+++ b/openshift/templates/streams-endpoints.json
@@ -212,7 +212,7 @@
           "spec": {
             "volumes": [
                 {"name": "nginx-job-configs", "emptyDir": {}},
-                {"name": "nginx-server-cert", "secret": {"secretName": "${NAME}-cert"}}
+                {"name": "server-cert", "secret": {"secretName": "${NAME}-cert"}}
             ],
             "containers": [
               {
@@ -220,7 +220,7 @@
                 "image": "${NAME}-nginx:latest",
                 "volumeMounts": [
                      {"name": "nginx-job-configs", "mountPath": "/opt/streams_job_configs"},
-                     {"name": "nginx-server-cert", "mountPath": "/var/run/secrets/endpoint-monitor", "readOnly":true}
+                     {"name": "server-cert", "mountPath": "/var/run/secrets/endpoint-monitor", "readOnly":true}
                 ],
                 "ports": [
                   {

--- a/openshift/templates/streams-endpoints.json
+++ b/openshift/templates/streams-endpoints.json
@@ -210,14 +210,17 @@
             }
           },
           "spec": {
-            "volumes": [ {"name": "nginx-job-configs", "emptyDir": {}}],
+            "volumes": [
+                {"name": "nginx-job-configs", "emptyDir": {}},
+                {"name": "nginx-server-cert", "secret": {"name": "${NAME}-cert"}},
+            ],
             "containers": [
               {
                 "name": "streams-nginx",
                 "image": "${NAME}-nginx:latest",
                 "volumeMounts": [
                      {"name": "nginx-job-configs", "mountPath": "/opt/streams_job_configs"},
-                     {"name": "${NAME}-nginx-cert", "mountPath": "/var/run/secrets/endpoint-monitor", "readOnly":true}
+                     {"name": "nginx-server-cert", "mountPath": "/var/run/secrets/endpoint-monitor", "readOnly":true}
                 ],
                 "ports": [
                   {
@@ -276,7 +279,7 @@
       "metadata": {
         "name": "${NAME}",
         "annotations": {
-          "service.alpha.openshift.io/serving-cert-secret-name": "${NAME}-nginx-cert",
+          "service.alpha.openshift.io/serving-cert-secret-name": "${NAME}-cert",
           "description": "Exposes IBM Streams application endpoints"
         }
       },

--- a/openshift/templates/streams-endpoints.json
+++ b/openshift/templates/streams-endpoints.json
@@ -231,6 +231,7 @@
                   "timeoutSeconds": 3,
                   "initialDelaySeconds": 3,
                   "httpGet": {
+                    "scheme": "HTTPS",
                     "path": "/",
                     "port": 8443
                   }
@@ -239,6 +240,7 @@
                     "timeoutSeconds": 3,
                     "initialDelaySeconds": 30,
                     "httpGet": {
+                        "scheme": "HTTPS",
                         "path": "/",
                         "port": 8443
                     }


### PR DESCRIPTION
Sets the nginx reverse proxy to only be an SSL/HTTPS server.

- Creates the main Nginx configuration in `nginx.conf`
- Only defines an SSL server on port 8443
- Auto creates SSL certificates for the service using Openshift annotation: https://docs.openshift.com/container-platform/3.11/dev_guide/secrets.html#service-serving-certificate-secrets
- Changes readiness and liveness probes to use HTTPS and correct 8443 port.

Fixes #16 