### PR TITLE
Add template that creates 1.14 image

### DIFF
--- a/openshift/templates/nginx-add-114.json
+++ b/openshift/templates/nginx-add-114.json
@@ -1,0 +1,34 @@
+{
+  "kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "nginx-add-114"
+  },
+  "message": "nginx:1.14 added to namespace ${NAMESPACE}",
+  "labels": {
+    "template": "nginx-add"
+  },
+  "objects": [
+    {
+      "kind": "ImageStreamTag",
+      "apiVersion": "v1",
+      "metadata": {
+         "namespace": "${NAMESPACE}",
+         "name": "nginx:1.14"
+      },
+      "tag": {
+         "from": {"kind":"DockerImage", "name":"docker.io/centos/nginx-114-centos7:latest"},
+         "name": "1.14"
+      }
+    }
+  ],
+  "parameters": [
+    {
+      "name": "NAMESPACE",
+      "displayName": "Namespace",
+      "description": "The OpenShift Namespace where the ImageStream resides.",
+      "required": true,
+      "value": "openshift"
+    }
+  ]
+}


### PR DESCRIPTION
A separate template that creates the 1.14 Nginx image in the required namespace, defaulting to `openshift`.

Separated from the application template as you cannot create the same object twice.

This is equivalent to

`oc tag docker.io/centos/nginx-114-centos7:latest nginx:1.14`

Not sure which is the best one to document, the `oc tag` or `oc new-app` with this new template. But wanted to record what a tag looked like in a template.