### PR TITLE
Move config info to /var/opt/streams-endpoint-monitor

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,7 +23,7 @@ job_group_pattern = os.environ['STREAMSX_ENDPOINT_JOB_GROUP']
 job_filter = lambda job : job.jobGroup.endswith('/'+job_group_pattern)
 print("Job group pattern:", job_group_pattern)
 
-cfg = FileWriter(location='/opt/streams_job_configs')
+cfg = FileWriter(location='/var/opt/streams-endpoint-monitor/job-configs')
 
 em = EndpointMonitor(endpoint=sws_service, config=cfg, job_filter=job_filter, verify=False)
 em.run()

--- a/file_config.py
+++ b/file_config.py
@@ -9,6 +9,8 @@ def server_url(server):
 class FileWriter(object):
     def __init__(self, location):
         self._location = location
+        if not os.path.exists(self._location):
+            os.mkdir(self._location)
         self._pipe_name = os.path.join(location, 'actions')
         
     def _reload(self):

--- a/nginx-default-cfg/nginx-proxy.conf
+++ b/nginx-default-cfg/nginx-proxy.conf
@@ -1,1 +1,1 @@
-include /opt/streams_job_configs/*.conf;
+include /var/opt/streams-endpoint-monitor/job-configs/*.conf;

--- a/nginx-start/nginx-action.sh
+++ b/nginx-start/nginx-action.sh
@@ -1,4 +1,4 @@
-af=/opt/streams_job_configs/actions
+af=/var/opt/streams-endpoint-monitor/job-configs/actions
 echo 'Starting action reader for' ${af}
 (
 while true

--- a/nginx.conf
+++ b/nginx.conf
@@ -45,8 +45,8 @@ http {
         root         /opt/app-root/src;
 
         ssl                  on;
-        ssl_certificate      /var/run/secrets/endpoint-monitor/tls.crt;
-        ssl_certificate_key  /var/run/secrets/endpoint-monitor/tls.key;
+        ssl_certificate      /var/run/secrets/streams-endpoint-monitor/server-cert/tls.crt;
+        ssl_certificate_key  /var/run/secrets/streams-endpoint-monitor/server-cert/tls.key;
 
         ssl_session_timeout  5m;
 

--- a/openshift/templates/streams-endpoints.json
+++ b/openshift/templates/streams-endpoints.json
@@ -211,7 +211,7 @@
           },
           "spec": {
             "volumes": [
-                {"name": "nginx-job-configs", "emptyDir": {}},
+                {"name": "shared-disk", "emptyDir": {}},
                 {"name": "server-cert", "secret": {"secretName": "${NAME}-cert"}}
             ],
             "containers": [
@@ -219,8 +219,8 @@
                 "name": "streams-nginx",
                 "image": "${NAME}-nginx:latest",
                 "volumeMounts": [
-                     {"name": "nginx-job-configs", "mountPath": "/opt/streams_job_configs"},
-                     {"name": "server-cert", "mountPath": "/var/run/secrets/endpoint-monitor", "readOnly":true}
+                     {"name": "shared-disk", "mountPath": "/var/opt/streams-endpoint-monitor"},
+                     {"name": "server-cert", "mountPath": "/var/run/secrets/streams-endpoint-monitor/server-cert", "readOnly":true}
                 ],
                 "ports": [
                   {
@@ -256,7 +256,9 @@
               {
                 "name": "streams-endpoint-monitor",
                 "image": "${NAME}-endpoint-monitor:latest",
-                "volumeMounts": [ {"name": "nginx-job-configs", "mountPath": "/opt/streams_job_configs"}],
+                "volumeMounts": [
+                  {"name": "shared-disk", "mountPath": "/var/opt/streams-endpoint-monitor"},
+                ],
                 "resources": {
                     "limits": {
                         "memory": "${MEMORY_LIMIT}"

--- a/openshift/templates/streams-endpoints.json
+++ b/openshift/templates/streams-endpoints.json
@@ -257,7 +257,7 @@
                 "name": "streams-endpoint-monitor",
                 "image": "${NAME}-endpoint-monitor:latest",
                 "volumeMounts": [
-                  {"name": "shared-disk", "mountPath": "/var/opt/streams-endpoint-monitor"},
+                  {"name": "shared-disk", "mountPath": "/var/opt/streams-endpoint-monitor"}
                 ],
                 "resources": {
                     "limits": {


### PR DESCRIPTION
Modifiable data should really be in `/var/opt`

Also use `job-configs` within the volume mount to allow expansion in the future, such as other directories with different purposes, like certificates.

Also consistently use `streams-endpoint-monitor` as top-level for config & secrets.