### PR TITLE
Pull in Nginx client certificate from optional secret

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,7 +8,7 @@ from endpoint_monitor import EndpointMonitor
 import streams_openshift
 
 OPT = '/var/opt/streams-endpoint-monitor'
-SECRETS = '/var/secrets/streams-endpoint-monitor'
+SECRETS = '/var/run/secrets/streams-endpoint-monitor'
 
 def _unpack_restop_certs():
     cert_file = os.path.join(SECRETS, 'streams-certs', 'client.pfx')

--- a/app.py
+++ b/app.py
@@ -1,10 +1,31 @@
 import os
 import re
+import subprocess
 import streamsx.scripts.info as info
 
 from file_config import FileWriter
 from endpoint_monitor import EndpointMonitor
 import streams_openshift
+
+OPT = '/var/opt/streams-endpoint-monitor'
+SECRETS = '/var/secrets/streams-endpoint-monitor'
+
+def _unpack_restop_certs():
+    cert_file = os.path.join(SECRETS, 'streams-certs', 'client.pfx')
+    if not os.path.exists(cert_file):
+        return
+
+    certs_dir = os.path.join(OPT, 'streams-certs')
+    if not os.path.exists(certs_dir):
+        os.mkdir(certs_dir)
+    crt = os.path.join(certs_dir, 'client.crt')
+    rsa = os.path.join(certs_dir, 'client.rsa')
+
+    ossl = '/usr/bin/openssl'
+    args = ['/usr/bin/openssl', 'pkcs12', '-in', cert_file]
+    subprocess.run(args + ['-clcerts', '-nokeys', '-out', crt], check=True)
+    subprocess.run(args + ['-nocerts', '-nodes', '-out', rsa], check=True)
+    return crt, rsa
 
 info.main()
 
@@ -23,10 +44,9 @@ job_group_pattern = os.environ['STREAMSX_ENDPOINT_JOB_GROUP']
 job_filter = lambda job : job.jobGroup.endswith('/'+job_group_pattern)
 print("Job group pattern:", job_group_pattern)
 
-cfg = FileWriter(location='/var/opt/streams-endpoint-monitor/job-configs')
+client_cert = _unpack_restop_certs()
+
+cfg = FileWriter(location=os.path.join(OPT, 'job-configs'), client_cert=client_cert)
 
 em = EndpointMonitor(endpoint=sws_service, config=cfg, job_filter=job_filter, verify=False)
 em.run()
-
-
-

--- a/app.py
+++ b/app.py
@@ -15,6 +15,7 @@ def _unpack_restop_certs():
     if not os.path.exists(cert_file):
         return
 
+    pwd_file = os.path.join(SECRETS, 'streams-certs', 'client.pass')
     certs_dir = os.path.join(OPT, 'streams-certs')
     if not os.path.exists(certs_dir):
         os.mkdir(certs_dir)
@@ -22,7 +23,7 @@ def _unpack_restop_certs():
     rsa = os.path.join(certs_dir, 'client.rsa')
 
     ossl = '/usr/bin/openssl'
-    args = ['/usr/bin/openssl', 'pkcs12', '-in', cert_file]
+    args = ['/usr/bin/openssl', 'pkcs12', '-in', cert_file, '--pass', 'file:' + pwd_file]
     subprocess.run(args + ['-clcerts', '-nokeys', '-out', crt], check=True)
     subprocess.run(args + ['-nocerts', '-nodes', '-out', rsa], check=True)
     return crt, rsa

--- a/app.py
+++ b/app.py
@@ -23,7 +23,7 @@ def _unpack_restop_certs():
     rsa = os.path.join(certs_dir, 'client.rsa')
 
     ossl = '/usr/bin/openssl'
-    args = ['/usr/bin/openssl', 'pkcs12', '-in', cert_file, '--pass', 'file:' + pwd_file]
+    args = ['/usr/bin/openssl', 'pkcs12', '-in', cert_file, '-password', 'file:' + pwd_file]
     subprocess.run(args + ['-clcerts', '-nokeys', '-out', crt], check=True)
     subprocess.run(args + ['-nocerts', '-nodes', '-out', rsa], check=True)
     return crt, rsa

--- a/file_config.py
+++ b/file_config.py
@@ -7,10 +7,11 @@ def server_url(server):
     return '%s://%s:%s/' % (server.proto, server.ip, server.port)
 
 class FileWriter(object):
-    def __init__(self, location):
+    def __init__(self, location, client_cert):
         self._location = location
         if not os.path.exists(self._location):
             os.mkdir(self._location)
+        self._client_cert = client_cert
         self._pipe_name = os.path.join(location, 'actions')
         
     def _reload(self):
@@ -71,4 +72,11 @@ class FileWriter(object):
         f.write('  proxy_set_header  X-Forwarded-Host $remote_addr;\n')
         #f.write('  proxy_pass %s://streams_job_%s/;\n' % (proto, jobid))
         f.write('  proxy_pass %s;\n' % (server_url(server)))
+
+        if proto == 'https':
+            if self._client_cert:
+                f.write('  proxy_ssl_certificate %s;\n' % self._client_cert[0])
+                f.write('  proxy_ssl_certificate_key %s;\n' % self._client_cert[1])
+     
+
         f.write('}\n')

--- a/openshift/templates/streams-endpoints.json
+++ b/openshift/templates/streams-endpoints.json
@@ -213,7 +213,7 @@
             "volumes": [
                 {"name": "shared-disk", "emptyDir": {}},
                 {"name": "server-cert", "secret": {"secretName": "${NAME}-cert"}},
-                {"name": "streams-certs", "secret": {"secretName": "${NAME}-streams-certs"}}
+                {"name": "streams-certs", "secret": {"secretName": "${NAME}-streams-certs", "optional":true}}
             ],
             "containers": [
               {

--- a/openshift/templates/streams-endpoints.json
+++ b/openshift/templates/streams-endpoints.json
@@ -212,7 +212,8 @@
           "spec": {
             "volumes": [
                 {"name": "shared-disk", "emptyDir": {}},
-                {"name": "server-cert", "secret": {"secretName": "${NAME}-cert"}}
+                {"name": "server-cert", "secret": {"secretName": "${NAME}-cert"}},
+                {"name": "streams-certs", "secret": {"secretName": "${NAME}-streams-certs"}}
             ],
             "containers": [
               {
@@ -257,7 +258,8 @@
                 "name": "streams-endpoint-monitor",
                 "image": "${NAME}-endpoint-monitor:latest",
                 "volumeMounts": [
-                  {"name": "shared-disk", "mountPath": "/var/opt/streams-endpoint-monitor"}
+                  {"name": "shared-disk", "mountPath": "/var/opt/streams-endpoint-monitor"},
+                  {"name": "streams-certs", "mountPath": "/var/run/secrets/streams-endpoint-monitor/streams-certs", "readOnly":true, "optional":true}
                 ],
                 "resources": {
                     "limits": {


### PR DESCRIPTION
The client certificate in `client.pfx`  is pulled in from a secret `${NAME}-streams-certs` and converted to the format needed by nginx using openssl.

Initial step for #14 

Additional work:

 * provide an example script to create the secret
 * create a Streams application configuration from the secret (for use by Streams apps)