### PR TITLE
Produce nginx binary compatible module

### DIFF
--- a/builds/nginx_njs/Dockerfile
+++ b/builds/nginx_njs/Dockerfile
@@ -6,7 +6,7 @@ ENV nginxversion="1.14.0-1" \
     osversion="7" \
     elversion="7_4"
 
-RUN yum install -y wget openssl sed &&\
+RUN yum install -y wget openssl.devel sed &&\
     yum -y autoremove &&\
     yum -y install gcc &&\
     yum -y group install "Development Tools" &&\

--- a/builds/nginx_njs/Dockerfile
+++ b/builds/nginx_njs/Dockerfile
@@ -6,7 +6,7 @@ ENV nginxversion="1.14.0-1" \
     osversion="7" \
     elversion="7_4"
 
-RUN yum install -y wget openssl.devel sed &&\
+RUN yum install -y wget openssl openssl-devel sed &&\
     yum -y autoremove &&\
     yum -y install gcc &&\
     yum -y group install "Development Tools" &&\

--- a/builds/nginx_njs/docker_script.sh
+++ b/builds/nginx_njs/docker_script.sh
@@ -21,5 +21,11 @@ make install
 # Build the ngx_http_js_module.so file
 cd ../nginx-1.14.1/
 make clean
-./configure --with-compat --with-pcre=../pcre-8.43/ --with-zlib=../zlib-1.2.11 --add-dynamic-module=../njs-0.3.5/nginx/
+./configure --with-pcre=../pcre-8.43/ --with-zlib=../zlib-1.2.11 \
+    --add-dynamic-module=../njs-0.3.5/nginx/ \
+    --with-file-aio \
+    --with-http_ssl_module \
+    --with-http_realip_module \
+    --with-http_dav_module \
+    --with-cc-opt='-DNGX_HTTP_HEADERS'
 make modules

--- a/builds/nginx_njs/get_ngx_njs.sh
+++ b/builds/nginx_njs/get_ngx_njs.sh
@@ -2,14 +2,7 @@
 echo 'Building dockerfile'
 docker build -t karstenf/endpoint_monitor:latest . 
 echo 'Running dockerfile'
-docker run --name endpointContainerKF -d karstenf/endpoint_monitor:latest
-sleep 40s
-RUNING=$(docker inspect -f '{{.State.Running}}' endpointContainerKF)
-while [ $RUNING = true ]; do
-    echo 'Container not finished running, sleeping for 10 seconds'
-    sleep 10s
-    RUNING=$(docker inspect -f '{{.State.Running}}' endpointContainerKF)
-done
+docker run --name endpointContainerKF karstenf/endpoint_monitor:latest
 docker cp endpointContainerKF:/nginx-1.14.1/objs/ngx_http_js_module.so .
 docker rm endpointContainerKF 
 if [ -f ./ngx_http_js_module.so ]; then

--- a/builds/nginx_njs/get_ngx_njs.sh
+++ b/builds/nginx_njs/get_ngx_njs.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 echo 'Building dockerfile'
-docker build -t karstenf/endpoint_monitor:latest . > /dev/null 2>&1
+docker build -t karstenf/endpoint_monitor:latest . 
 echo 'Running dockerfile'
 docker run --name endpointContainerKF -d karstenf/endpoint_monitor:latest
 sleep 40s
@@ -11,7 +11,7 @@ while [ $RUNING = true ]; do
     RUNING=$(docker inspect -f '{{.State.Running}}' endpointContainerKF)
 done
 docker cp endpointContainerKF:/nginx-1.14.1/objs/ngx_http_js_module.so .
-docker rm endpointContainerKF > /dev/null 2>&1
+docker rm endpointContainerKF 
 if [ -f ./ngx_http_js_module.so ]; then
     echo 'Container removed, ngx_http_js_module.so file copied to current directory'
 else


### PR DESCRIPTION
Changes to produce a module binary compatible with the nginx114 signature.

Helped by these items:

https://github.com/vozlt/nginx-module-vts/issues/128

https://github.com/apache/incubator-pagespeed-ngx/issues/1440#issuecomment-315520779

nginx 114 for the RedHat version signature is:
```
8,4,8,0010111111010111001110111111111110
```