### PR TITLE
remove regex for UUID in instance name

### DIFF
--- a/streams_openshift.py
+++ b/streams_openshift.py
@@ -14,8 +14,8 @@ def _find_env_var(pattern):
 
 def get_sws_service(instance_name):
     ievn = _convert_name_to_ev(instance_name)
-    host = _find_env_var(ievn + '_[0-9A-Z]+_SWS_SERVICE_HOST')
-    port = _find_env_var(ievn + '_[0-9A-Z]+_SWS_SERVICE_PORT')
+    host = _find_env_var(ievn + '_SWS_SERVICE_HOST')
+    port = _find_env_var(ievn + '_SWS_SERVICE_PORT')
     if host and port:
         return 'https://{0}:{1}'.format(host, port)
 


### PR DESCRIPTION
Neither standalone nor CPD installs use this anymore.