### PR TITLE
Fill in context/path information in ServerDetail

### DIFF
--- a/app.py
+++ b/app.py
@@ -67,7 +67,7 @@ client_cert = _process_streams_certs()
 
 cfg = FileWriter(location=os.path.join(OPT, 'job-configs'), client_cert=client_cert, signature=_has_signature_secret())
 
-em = EndpointMonitor(endpoint=sws_service, config=cfg, job_filter=job_filter, client_cert, verify=False)
+em = EndpointMonitor(endpoint=sws_service, config=cfg, job_filter=job_filter, client_cert=client_cert, verify=False)
 
 # Create the application configuration
 certs_secret = os.path.join(SECRETS, 'streams-certs')

--- a/app.py
+++ b/app.py
@@ -67,7 +67,7 @@ client_cert = _process_streams_certs()
 
 cfg = FileWriter(location=os.path.join(OPT, 'job-configs'), client_cert=client_cert, signature=_has_signature_secret())
 
-em = EndpointMonitor(endpoint=sws_service, config=cfg, job_filter=job_filter, verify=False)
+em = EndpointMonitor(endpoint=sws_service, config=cfg, job_filter=job_filter, client_cert, verify=False)
 
 # Create the application configuration
 certs_secret = os.path.join(SECRETS, 'streams-certs')

--- a/endpoint_monitor.py
+++ b/endpoint_monitor.py
@@ -11,7 +11,7 @@ import rest_ops
 
 Server = collections.namedtuple('Server', ['proto', 'ip', 'port', 'pe_id'])
 
-ServerDetail = collections.namedtuple('ServerDetails', ['url', 'contexts'])
+ServerDetail = collections.namedtuple('ServerDetails', ['url', 'contexts', 'paths'])
 
 def _get_server_address(op, pe):
     # No get_resource on PE

--- a/endpoint_monitor.py
+++ b/endpoint_monitor.py
@@ -136,11 +136,12 @@ def _check_if_server_in_pe(job_info, pe_id):
     return False
 
 class EndpointMonitor(object):
-    def __init__(self, endpoint, config, job_filter, verify=None):
+    def __init__(self, endpoint, config, job_filter, client_cert, verify=None):
         self._jobs = {}
         self._endpoint = endpoint
         self._config = config
         self._job_filter = job_filter
+        self._client_cert = client_cert
         self._verify = verify
         self._inst = None
 
@@ -207,7 +208,7 @@ class EndpointMonitor(object):
     def _update_job(self, jobid, ne):
         print("UPDATE:", jobid, ne)
         if ne.servers:
-            rest_ops.fill_in_details(ne)
+            rest_ops.fill_in_details(ne, self._client_cert)
             self._config.update(jobid, self._jobs[jobid], ne)
         self._jobs[jobid] = ne
 
@@ -215,7 +216,7 @@ class EndpointMonitor(object):
     def _new_job(self, jobid, ne):
         print("NEW:", jobid, ne, bool(ne.servers))
         if ne.servers:
-            rest_ops.fill_in_details(ne)
+            rest_ops.fill_in_details(ne, self._client_cert)
             self._config.create(jobid, ne)
         self._jobs[jobid] = ne
 

--- a/endpoint_monitor.py
+++ b/endpoint_monitor.py
@@ -11,7 +11,7 @@ import rest_ops
 
 Server = collections.namedtuple('Server', ['proto', 'ip', 'port', 'pe_id'])
 
-ServerDetail = collections.namedtuple('ServerDetails', ['url', 'contexts', 'paths'])
+ServerDetail = collections.namedtuple('ServerDetails', ['url', 'contexts', 'paths', 'ports'])
 
 def _get_server_address(op, pe):
     # No get_resource on PE

--- a/rest_ops.py
+++ b/rest_ops.py
@@ -9,13 +9,13 @@ def server_url(server):
 
 
 # Currently unused
-def find_contexts(server):
+def find_contexts(server, client_cert):
     if proto != 'http':
         return set(), set()
     oppaths=set()
     contexts=set()
     ports_url = server_url(server) + 'ports/info'
-    ports = requests.get(ports_url, verify=False).json()
+    ports = requests.get(ports_url, cert=client_cert, verify=False).json()
     if 'exposedPorts' in ports:
         for port in ports['exposedPorts']:
             cps = port['contextPaths']
@@ -28,8 +28,10 @@ def find_contexts(server):
     return oppaths, contexts
 
 
-def fill_in_details(endjob):
+def fill_in_details(endjob, client_cert):
     for server in endjob.servers:
         url = server_url(server)
-        contexts = set()
+        oppaths, contexts = find_contexts(server, client_certs)
         endjob.server_details[server] = endpoint_monitor.ServerDetail(url, contexts)
+        print('Server', server)
+        print('ServerDetail', endjob.server_details[server])

--- a/rest_ops.py
+++ b/rest_ops.py
@@ -31,7 +31,7 @@ def find_contexts(server, url, client_cert):
 def fill_in_details(endjob, client_cert):
     for server in endjob.servers:
         url = server_url(server)
-        contexts, paths = find_contexts(server, url, client_cert)
-        endjob.server_details[server] = endpoint_monitor.ServerDetail(url, contexts, paths, exposed_ports)
+        contexts, paths, ports = find_contexts(server, url, client_cert)
+        endjob.server_details[server] = endpoint_monitor.ServerDetail(url, contexts, paths, ports)
         print('Server', server)
         print('ServerDetail', endjob.server_details[server])

--- a/rest_ops.py
+++ b/rest_ops.py
@@ -1,15 +1,23 @@
 # Licensed Materials - Property of IBM
 # Copyright IBM Corp. 2019
 
+#
+# Code that handles specifics and interactions
+# with the Jetty servers running in the REST operators.
+#
+
 import requests
 import endpoint_monitor
 
 def server_url(server):
     return '%s://%s:%s/' % (server.proto, server.ip, server.port)
 
+# Pull information ports/info for the Jetty server to
+# identify contexts, paths and exposed ports.
+#
+# Returns set of contexts, set of paths and the exposed ports information
 
-# Currently unused
-def find_contexts(server, url, client_cert):
+def _find_contexts(server, url, client_cert):
     oppaths=set()
     contexts=set()
     exposed_ports = None
@@ -27,11 +35,14 @@ def find_contexts(server, url, client_cert):
 
     return contexts, oppaths, exposed_ports
 
-
+#
+# Fills in the details for a given server to return
+# a ServerDetail tuple.
+#
 def fill_in_details(endjob, client_cert):
     for server in endjob.servers:
         url = server_url(server)
-        contexts, paths, ports = find_contexts(server, url, client_cert)
+        contexts, paths, ports = _find_contexts(server, url, client_cert)
         endjob.server_details[server] = endpoint_monitor.ServerDetail(url, contexts, paths, ports)
         print('Server', server)
         print('ServerDetail', endjob.server_details[server])

--- a/rest_ops.py
+++ b/rest_ops.py
@@ -12,10 +12,12 @@ def server_url(server):
 def find_contexts(server, url, client_cert):
     oppaths=set()
     contexts=set()
+    exposed_ports = None
     ports_url = url + 'ports/info'
     ports = requests.get(ports_url, cert=client_cert, verify=False).json()
     if 'exposedPorts' in ports:
-        for port in ports['exposedPorts']:
+        exposed_ports = ports['exposedPorts']
+        for port in exposed_ports:
             cps = port['contextPaths']
             for id_ in cps:
                 cp = cps[id_].replace('\\', '')
@@ -23,13 +25,13 @@ def find_contexts(server, url, client_cert):
                 contexts.add(scp[1])
                 oppaths.add(scp[1]+'/'+scp[2])
 
-    return contexts, oppaths
+    return contexts, oppaths, exposed_ports
 
 
 def fill_in_details(endjob, client_cert):
     for server in endjob.servers:
         url = server_url(server)
         contexts, paths = find_contexts(server, url, client_cert)
-        endjob.server_details[server] = endpoint_monitor.ServerDetail(url, contexts, paths)
+        endjob.server_details[server] = endpoint_monitor.ServerDetail(url, contexts, paths, exposed_ports)
         print('Server', server)
         print('ServerDetail', endjob.server_details[server])

--- a/rest_ops.py
+++ b/rest_ops.py
@@ -9,12 +9,10 @@ def server_url(server):
 
 
 # Currently unused
-def find_contexts(server, client_cert):
-    if proto != 'http':
-        return set(), set()
+def find_contexts(server, url, client_cert):
     oppaths=set()
     contexts=set()
-    ports_url = server_url(server) + 'ports/info'
+    ports_url = url + 'ports/info'
     ports = requests.get(ports_url, cert=client_cert, verify=False).json()
     if 'exposedPorts' in ports:
         for port in ports['exposedPorts']:
@@ -31,7 +29,7 @@ def find_contexts(server, client_cert):
 def fill_in_details(endjob, client_cert):
     for server in endjob.servers:
         url = server_url(server)
-        oppaths, contexts = find_contexts(server, client_cert)
+        oppaths, contexts = find_contexts(server, url, client_cert)
         endjob.server_details[server] = endpoint_monitor.ServerDetail(url, contexts)
         print('Server', server)
         print('ServerDetail', endjob.server_details[server])

--- a/rest_ops.py
+++ b/rest_ops.py
@@ -23,13 +23,13 @@ def find_contexts(server, url, client_cert):
                 contexts.add(scp[1])
                 oppaths.add(scp[1]+'/'+scp[2])
 
-    return oppaths, contexts
+    return contexts, oppaths
 
 
 def fill_in_details(endjob, client_cert):
     for server in endjob.servers:
         url = server_url(server)
-        oppaths, contexts = find_contexts(server, url, client_cert)
-        endjob.server_details[server] = endpoint_monitor.ServerDetail(url, contexts)
+        contexts, paths = find_contexts(server, url, client_cert)
+        endjob.server_details[server] = endpoint_monitor.ServerDetail(url, contexts, paths)
         print('Server', server)
         print('ServerDetail', endjob.server_details[server])

--- a/rest_ops.py
+++ b/rest_ops.py
@@ -31,7 +31,7 @@ def find_contexts(server, client_cert):
 def fill_in_details(endjob, client_cert):
     for server in endjob.servers:
         url = server_url(server)
-        oppaths, contexts = find_contexts(server, client_certs)
+        oppaths, contexts = find_contexts(server, client_cert)
         endjob.server_details[server] = endpoint_monitor.ServerDetail(url, contexts)
         print('Server', server)
         print('ServerDetail', endjob.server_details[server])


### PR DESCRIPTION
Makes a request against each Jetty server's `ports/info` path to determine which contexts are supported (the first element of a path), which paths are supported for each operator (the lead-in for an operator), and maintain the complete exposedPorts information.

Nothing is yet done with this info, but the next step is to write additional ngnix config entries so that multiple servers within a single job can be supported.

Passes the tests.

Example of the server details filled in from one of the tests.
```
Server Server(proto=‘https’, ip=‘172.17.0.13’, port=46816, pe_id=‘20’)
ServerDetail ServerDetails(url=‘https://172.17.0.13:46816/’ , 
  contexts={‘CTABUAEO’}, paths={‘CTABUAEO/NXGLODQQ’}, 
ports=[{‘operatorKind’: ‘com.ibm.streamsx.inet.rest::HTTPJSONInjection’, ‘contextPaths’: {‘inject’: ‘/CTABUAEO/NXGLODQQ/ports/output/0/inject’, ‘info’: ‘/CTABUAEO/NXGLODQQ/ports/output/0/info’}, ‘portName’: ‘NXGLODQQ’, ‘operatorName’: ‘NXGLODQQ’}])
```