### PR TITLE
Support multiple servers.

### DIFF
--- a/file_config.py
+++ b/file_config.py
@@ -71,6 +71,7 @@ class FileWriter(object):
             for c in details.contexts:
                 loc = location + c + '/'
                 url = server_root_url + c + '/'
+                self._proxy_entry(f, loc, proto, url)
 
         # A final catch all, but only if there is a single server
         if len(job_config.servers) == 1:

--- a/file_config.py
+++ b/file_config.py
@@ -64,7 +64,39 @@ class FileWriter(object):
             proto = server.proto
             details = job_config.server_details[server]
             server_root_url = details.url
+ 
+            # The job is exposed as a single logical entry
+            # under location/*
 
+            # However the job may contain multiple REST endpoint
+            # operators in multiple servers. This is to avoid forcing
+            # unrelated operators into the same PE and hence same
+            # server. For example an inject operator should not be
+            # forced into a tuple view (expose) operator that
+            # is at the end of the analytic flow.
+
+            # This for example we may have operators of:
+            # C1/A  - Server S1
+            # C2/B  - Server S1
+            # C1/C  - Server S2
+            
+            # Thus we create proxy mappings as follows:
+
+            # Contexts that will resolve static files
+            # exposed by the operator(s)
+            # The assumption is that if a job is exposing a context
+            # and resource files then they files are consistent across
+            # operators.
+            # C1    ----> S1/C1
+            # C2    ----> S1/C2
+            # C1    ----> S2/C1
+
+            # Operator paths that will resolve paths specific
+            # to an individual operator's ports/streams
+            # C1/A  ----> S1/C1/A
+            # C2/B  ----> S1/C2/B
+            # C1/C  ----> S2/C1/C
+       
             if multi_servers:
                 for p in details.paths:
                     loc = location + p + '/'

--- a/file_config.py
+++ b/file_config.py
@@ -58,22 +58,26 @@ class FileWriter(object):
         f.write('  proxy_pass https://ajax.googleapis.com/ajax/libs/dojo/1.14.1/;\n')
         f.write('}\n')
 
+        multi_servers = len(job_config.servers) > 1
+
         for server in job_config.servers:
             proto = server.proto
             details = job_config.server_details[server]
             server_root_url = details.url
 
-            for p in details.paths:
-                loc = location + p + '/'
-                url = server_root_url + p + '/'
-                self._proxy_entry(f, loc, proto, url)
+            if multi_servers:
+                for p in details.paths:
+                    loc = location + p + '/'
+                    url = server_root_url + p + '/'
+                    self._proxy_entry(f, loc, proto, url)
 
-            for c in details.contexts:
-                loc = location + c + '/'
-                url = server_root_url + c + '/'
-                self._proxy_entry(f, loc, proto, url)
+                for c in details.contexts:
+                    loc = location + c + '/'
+                    url = server_root_url + c + '/'
+                    self._proxy_entry(f, loc, proto, url)
 
-        # A final catch all, but only if there is a single server
+        # A final catch all
+        # Is the sole location for a single server
         # Maps to only one of the servers.
         self._proxy_entry(f, location, proto, server_root_url)
 

--- a/file_config.py
+++ b/file_config.py
@@ -74,8 +74,8 @@ class FileWriter(object):
                 self._proxy_entry(f, loc, proto, url)
 
         # A final catch all, but only if there is a single server
-        if len(job_config.servers) == 1:
-            self._proxy_entry(f, location, proto, server_root_url)
+        # Maps to only one of the servers.
+        self._proxy_entry(f, location, proto, server_root_url)
 
     def _proxy_entry(self, f, location, proto, target_url):
 

--- a/file_config.py
+++ b/file_config.py
@@ -68,6 +68,10 @@ class FileWriter(object):
                 url = server_root_url + p + '/'
                 self._proxy_entry(f, loc, proto, url)
 
+            for c in details.contexts:
+                loc = location + c + '/'
+                url = server_root_url + c + '/'
+
         # A final catch all, but only if there is a single server
         if len(job_config.servers) == 1:
             self._proxy_entry(f, location, proto, server_root_url)
@@ -81,7 +85,7 @@ class FileWriter(object):
         # the server (as it is not protected by any signature authentication).
 
         # The external location
-        f.write('location %s {\n' % location)
+        f.write('location ^~ %s {\n' % location)
         if self._signature:
             f.write("  set $redirectLocation '/@internal%s';\n" % location)
             f.write("  js_content checkHTTP;\n")
@@ -90,7 +94,7 @@ class FileWriter(object):
         f.write('}\n')
 
         if self._signature:
-            f.write('location /@internal%s {\n' % location)
+            f.write('location ~^ /@internal%s {\n' % location)
             f.write('  internal;\n');
             self._proxy_location(f, proto, target_url)
             f.write('}\n')

--- a/file_config.py
+++ b/file_config.py
@@ -67,6 +67,10 @@ class FileWriter(object):
 
         server_root_url = job_config.server_details[server].url
 
+        self._proxy_entry(location, server_root_url)
+
+    def _proxy_entry(self, location, target_url):
+
         # If we are checking signatures then two locations are
         # created. The external one that invokes Javascript
         # to verify the signature and then redirect to the internal one.
@@ -79,13 +83,13 @@ class FileWriter(object):
             f.write("  set $redirectLocation '/@internal%s';\n" % location)
             f.write("  js_content checkHTTP;\n")
         else:
-            self._proxy_location(f, proto, server_root_url)
+            self._proxy_location(f, proto, target_url)
         f.write('}\n')
 
         if self._signature:
             f.write('location /@internal%s {\n' % location)
             f.write('  internal;\n');
-            self._proxy_location(f, proto, server_root_url)
+            self._proxy_location(f, proto, target_url)
             f.write('}\n')
 
     def _proxy_location(self, f, proto, url):

--- a/file_config.py
+++ b/file_config.py
@@ -67,9 +67,9 @@ class FileWriter(object):
 
         server_root_url = job_config.server_details[server].url
 
-        self._proxy_entry(location, server_root_url)
+        self._proxy_entry(f, location, proto, server_root_url)
 
-    def _proxy_entry(self, location, target_url):
+    def _proxy_entry(self, f, location, proto, target_url):
 
         # If we are checking signatures then two locations are
         # created. The external one that invokes Javascript

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -7,6 +7,7 @@ import string
 import unittest
 
 from streamsx.topology.topology import Topology
+from streamsx.topology.context import JobConfig
 from streamsx.topology.tester import Tester
 import streamsx.endpoint as endpoint
 import streamsx.spl.toolkit
@@ -15,9 +16,10 @@ import queue
 import os
 import requests
 import time
+import shutil
 
 def _rand_path():
-    return ''.join(random.choices(string.ascii_uppercase, k=8))
+    return ''.join(random.choices(string.ascii_uppercase, k=12))
   
 class TestEmInject(unittest.TestCase):
     _multiprocess_can_split_ = True
@@ -27,11 +29,18 @@ class TestEmInject(unittest.TestCase):
     def setupClass(cls):
         TestEmInject._TK = endpoint.download_toolkit()
 
+    @classmethod
+    def tearDownClass(cls):
+        if TestEmInject._TK:
+            shutil.rmtree(TestEmInject._TK)
+
     def setUp(self):
         Tester.setup_distributed(self)
         self._base_url = os.environ['ENDPOINT_MONITOR']
         self._job_name = None
+        self._monitor = os.environ.get('ENDPOINT_NAME')
         self.N = 163
+        self.K = 'seq'
 
     def _set_job_url(self):
         job = self.tester.submission_result.job
@@ -61,7 +70,7 @@ class TestEmInject(unittest.TestCase):
 
         url = self._job_url + self._path
         for i in range(self.N):
-            data = {'seq': i}
+            data = {self.K: i}
             rc = requests.post(url=url, json=data, verify=False)
             self.assertEqual(rc.status_code, 204, str(rc))
 
@@ -88,7 +97,51 @@ class TestEmInject(unittest.TestCase):
         self.tester = Tester(topo)
         self.tester.local_check = self._inject
         self.tester.tuple_count(s, self.N)
-        self.tester.contents(s, [{'seq':i} for i in range(self.N)])
+        self.tester.contents(s, [{self.K:i} for i in range(self.N)])
         self.tester.test(self.test_ctxtype, self.test_config)
 
         self._check_no_endpoint()
+
+    def test_multi_inject(self):
+        self._multi_injection()
+
+    def test_multi_servers(self):
+        self._multi_injection(raw_overlay = {'deploymentConfig': {'fusionScheme': 'legacy'}})
+
+    def _multi_injection(self, raw_overlay=None):
+        topo = Topology()
+        streamsx.spl.toolkit.add_toolkit(topo, TestEmInject._TK)
+        context = _rand_path()
+        name = _rand_path()
+        job_name = _rand_path()
+        s1 = endpoint.inject(topo, name=name+'N1', context=context+'C1', monitor=self._monitor)
+        s2 = endpoint.inject(topo, name=name+'N2', context=context+'C2', monitor=self._monitor)
+        jc = JobConfig()
+        self._job_name = _rand_path()
+        jc.job_name = self._job_name
+        jc.add(self.test_config)
+        # Force separate PEs for the inject operators
+   
+        if raw_overlay:
+            jc.raw_overlay = raw_overlay
+        else:
+            s1.colocate(s2)
+
+        self._path = '/' + context + 'C1/' + name + 'N1/ports/output/0/inject';
+
+        self.tester = Tester(topo)
+        self.tester.local_check = self._multi_inject
+        self.tester.contents(s1, [{'seq1':i} for i in range(self.N)])
+        self.tester.contents(s2, [{'seq2':i} for i in range(self.N)])
+
+        self.tester.test(self.test_ctxtype, self.test_config)
+
+        self._check_no_endpoint()
+
+    def _multi_inject(self):
+        self.K = 'seq1'
+        self._inject()
+
+        self.K = 'seq2'
+        self._path = self._path.replace('N1/', 'N2/').replace('C1/', 'C2/')
+        self._inject()


### PR DESCRIPTION
Supports multiple servers in a job (in separate PEs) by writing explicit proxy location entries for context and operator path the server supports.