### PR TITLE
Add aliases for operator main actions.

### DIFF
--- a/endpoint_monitor.py
+++ b/endpoint_monitor.py
@@ -11,7 +11,7 @@ import rest_ops
 
 Server = collections.namedtuple('Server', ['proto', 'ip', 'port', 'pe_id'])
 
-ServerDetail = collections.namedtuple('ServerDetails', ['url', 'contexts', 'paths', 'ports'])
+ServerDetail = collections.namedtuple('ServerDetails', ['url', 'contexts', 'paths', 'ports', 'aliases'])
 
 def _get_server_address(op, pe):
     # No get_resource on PE

--- a/file_config.py
+++ b/file_config.py
@@ -60,7 +60,6 @@ class FileWriter(object):
 
         multi_servers = len(job_config.servers) > 1
         seen_contexts = set()
-
  
         for server in job_config.servers:
             proto = server.proto
@@ -105,7 +104,7 @@ class FileWriter(object):
                     self._proxy_entry(f, loc, proto, url)
 
                 for c in details.contexts:
-                    if not c in seen_contexts():
+                    if not c in seen_contexts:
                         loc = location + c + '/'
                         url = server_root_url + c + '/'
                         self._proxy_entry(f, loc, proto, url)

--- a/file_config.py
+++ b/file_config.py
@@ -110,8 +110,8 @@ class FileWriter(object):
 
             # Aliases to operator functional paths (e.g. inject)
             for a,p in details.aliases.items():
-                loc = location + a 
-                url = server_root_url + p
+                loc = location + a.replace('/','',1) 
+                url = server_root_url + p.replace('/','',1)
                 self._proxy_entry(f, loc, proto, url)
 
         # A final catch all

--- a/file_config.py
+++ b/file_config.py
@@ -108,6 +108,12 @@ class FileWriter(object):
                     url = server_root_url + c + '/'
                     self._proxy_entry(f, loc, proto, url)
 
+            # Aliases to operator functional paths (e.g. inject)
+            for a,p in details.aliases.items():
+                loc = location + a 
+                url = server_root_url + p
+                self._proxy_entry(f, loc, proto, url)
+
         # A final catch all
         # Is the sole location for a single server
         # Maps to only one of the servers.

--- a/file_config.py
+++ b/file_config.py
@@ -59,7 +59,9 @@ class FileWriter(object):
         f.write('}\n')
 
         multi_servers = len(job_config.servers) > 1
+        seen_contexts = set()
 
+ 
         for server in job_config.servers:
             proto = server.proto
             details = job_config.server_details[server]
@@ -89,7 +91,6 @@ class FileWriter(object):
             # operators.
             # C1    ----> S1/C1
             # C2    ----> S1/C2
-            # C1    ----> S2/C1
 
             # Operator paths that will resolve paths specific
             # to an individual operator's ports/streams
@@ -104,9 +105,11 @@ class FileWriter(object):
                     self._proxy_entry(f, loc, proto, url)
 
                 for c in details.contexts:
-                    loc = location + c + '/'
-                    url = server_root_url + c + '/'
-                    self._proxy_entry(f, loc, proto, url)
+                    if not c in seen_contexts():
+                        loc = location + c + '/'
+                        url = server_root_url + c + '/'
+                        self._proxy_entry(f, loc, proto, url)
+                        seen_contexts.add(c)
 
             # Aliases to operator functional paths (e.g. inject)
             for a,p in details.aliases.items():

--- a/rest_ops.py
+++ b/rest_ops.py
@@ -41,7 +41,7 @@ def _make_port_alias(path, port, output=True):
     r += '/'
     r += str(port)
     r += '/'
-    alias = path.replace(r)
+    alias = path.replace(r, '')
     if alias != path:
         return path
 

--- a/rest_ops.py
+++ b/rest_ops.py
@@ -35,7 +35,7 @@ def _find_contexts(server, url, client_cert):
 
     return contexts, oppaths, exposed_ports
 
-def _make_port_alias(path, port, output=True)
+def _make_port_alias(path, port, output=True):
     r = '/ports/'
     r += 'output' if output else 'input'
     r += '/'

--- a/rest_ops.py
+++ b/rest_ops.py
@@ -43,7 +43,7 @@ def _make_port_alias(path, port, output=True):
     r += '/'
     alias = path.replace(r, '')
     if alias != path:
-        return path
+        return alias
 
 def _add_alias(aliases, path, port, output=True):
     alias = _make_port_alias(path, 0)

--- a/rest_ops.py
+++ b/rest_ops.py
@@ -54,7 +54,7 @@ def _create_aliases(ports):
     aliases = {}
     for port in ports:
         kind = port['operatorKind']
-        if kind == 'com.ibm.streamsx.inet.rest::HTTPJsonInject':
+        if kind == 'com.ibm.streamsx.inet.rest::HTTPJsonInjection':
             cps = port['contextPaths']
             _add_alias(aliases, cps['inject'], 0)
 

--- a/rest_ops.py
+++ b/rest_ops.py
@@ -41,7 +41,7 @@ def _make_port_alias(path, port, output=True):
     r += '/'
     r += str(port)
     r += '/'
-    alias = path.replace(r, '')
+    alias = path.replace(r, '/')
     if alias != path:
         return alias
 
@@ -52,9 +52,10 @@ def _add_alias(aliases, path, port, output=True):
 
 def _create_aliases(ports):
     aliases = {}
+    single = len(ports) == 1
     for port in ports:
         kind = port['operatorKind']
-        if kind == 'com.ibm.streamsx.inet.rest::HTTPJSONInjection':
+        if single and kind == 'com.ibm.streamsx.inet.rest::HTTPJSONInjection':
             cps = port['contextPaths']
             _add_alias(aliases, cps['inject'], 0)
 
@@ -70,6 +71,6 @@ def fill_in_details(endjob, client_cert):
         contexts, paths, ports = _find_contexts(server, url, client_cert)
         aliases = _create_aliases(ports)
         print('Aliases', aliases)
-        endjob.server_details[server] = endpoint_monitor.ServerDetail(url, contexts, paths, ports)
+        endjob.server_details[server] = endpoint_monitor.ServerDetail(url, contexts, paths, ports, aliases)
         print('Server', server)
         print('ServerDetail', endjob.server_details[server])

--- a/rest_ops.py
+++ b/rest_ops.py
@@ -54,7 +54,7 @@ def _create_aliases(ports):
     aliases = {}
     for port in ports:
         kind = port['operatorKind']
-        if kind == 'com.ibm.streamsx.inet.rest::HTTPJsonInjection':
+        if kind == 'com.ibm.streamsx.inet.rest::HTTPJSONInjection':
             cps = port['contextPaths']
             _add_alias(aliases, cps['inject'], 0)
 

--- a/rest_ops.py
+++ b/rest_ops.py
@@ -46,9 +46,9 @@ def _make_port_alias(path, port, output=True):
         return path
 
 def _add_alias(aliases, path, port, output=True):
-    alias = _make_port_alias(inject, 0)
+    alias = _make_port_alias(path, 0)
     if alias:
-        aliases[alias] = inject
+        aliases[alias] = path
 
 def _create_aliases(ports):
     aliases = {}

--- a/rest_ops.py
+++ b/rest_ops.py
@@ -35,6 +35,31 @@ def _find_contexts(server, url, client_cert):
 
     return contexts, oppaths, exposed_ports
 
+def _make_port_alias(path, port, output=True)
+    r = '/ports/'
+    r += 'output' if output else 'input'
+    r += '/'
+    r += str(port)
+    r += '/'
+    alias = path.replace(r)
+    if alias != path:
+        return path
+
+def _add_alias(aliases, path, port, output=True):
+    alias = _make_port_alias(inject, 0)
+    if alias:
+        aliases[alias] = inject
+
+def _create_aliases(ports):
+    aliases = {}
+    for port in ports:
+        kind = port['operatorKind']
+        if kind == 'com.ibm.streamsx.inet.rest::HTTPJsonInject':
+            cps = port['contextPaths']
+            _add_alias(aliases, cps['inject'], 0)
+
+    return aliases
+    
 #
 # Fills in the details for a given server to return
 # a ServerDetail tuple.
@@ -43,6 +68,8 @@ def fill_in_details(endjob, client_cert):
     for server in endjob.servers:
         url = server_url(server)
         contexts, paths, ports = _find_contexts(server, url, client_cert)
+        aliases = _create_aliases(ports)
+        print('Aliases', aliases)
         endjob.server_details[server] = endpoint_monitor.ServerDetail(url, contexts, paths, ports)
         print('Server', server)
         print('ServerDetail', endjob.server_details[server])

--- a/tests/test_inject.py
+++ b/tests/test_inject.py
@@ -39,6 +39,7 @@ class TestEmInject(unittest.TestCase):
         self._base_url = os.environ['ENDPOINT_MONITOR']
         self._job_name = None
         self._monitor = os.environ.get('ENDPOINT_NAME')
+        self._alias = None
         self.N = 163
         self.K = 'seq'
 
@@ -68,9 +69,13 @@ class TestEmInject(unittest.TestCase):
         self._set_job_url()
         self._wait_for_endpoint()
 
-        url = self._job_url + self._path
+        # switch between the full traditional URL and the alias created
+        # by the endpoint monitor
+        url_full = self._job_url + self._path
+        url_alias = self._job_url + self._alias if self._alias else None
         for i in range(self.N):
             data = {self.K: i}
+            url = url_alias if url_alias and i % 2 == 0 else url_full
             rc = requests.post(url=url, json=data, verify=False)
             self.assertEqual(rc.status_code, 204, str(rc))
 
@@ -93,6 +98,7 @@ class TestEmInject(unittest.TestCase):
         streamsx.spl.toolkit.add_toolkit(topo, TestEmInject._TK)
 
         self._path = '/' + context + '/' + name + '/ports/output/0/inject';
+        self._alias = '/' + context + '/' + name + '/inject';
 
         self.tester = Tester(topo)
         self.tester.local_check = self._inject


### PR DESCRIPTION
For specific operators add an alias to simplify the URL and hide the concept of `ports` since they are an SPL detail, not exposed through the Python API.

This PR adds the mechanism and adds a single alias for JSON injection. Follow on PRs will add more aliases.

The path alias for the the inject POST is: _job_prefix/context/name_/`inject`

e.g. for a job named transit, with an inject Python endpoint with context `nextbus` and name `buslocations`:

```
transit/nextbus/buslocations/inject
```

This is instead of `transit/nextbus/buslocations/ports/output/0/inject`